### PR TITLE
Add Integrations Test for Solvers

### DIFF
--- a/.thoth.yaml
+++ b/.thoth.yaml
@@ -1,0 +1,28 @@
+host: khemenu.thoth-station.ninja
+tls_verify: false
+requirements_format: pipenv
+
+runtime_environments:
+  - name: rhel:8
+    operating_system:
+      name: rhel
+      version: "8"
+    python_version: "3.6"
+    recommendation_type: latest
+
+managers:
+  - name: pipfile-requirements
+  - name: update
+    configuration:
+      labels: [bot]
+  - name: info
+  - name: version
+    configuration:
+      maintainers:
+        - fridex
+        - goern
+        - pacospace
+      assignees:
+        - sesheta
+      labels: [bot]
+      changelog_file: true

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,8 @@ The integration testsuite is written in `behave <https://behave.readthedocs.io/>
 
 The command above will trigger installation of all the necessary libraries and executing the test-suite in a virtual environment. By default, test environment is tested with integration tests. The script above can be parametrized using the following environment variables:
 
-* THOTH_USER_API_URL - an URL to deployment where User API sits
+* THOTH_USER_API_HOST - the HOST to deployment where User API sits
+* THOTH_MANAGEMENT_API_HOST - the HOST to deployment where Management API sits
 * NO_INSTALL - do not install dependencies (expects that the `pipenv install` command was already issued)
 
 Examples
@@ -25,7 +26,7 @@ Run integration tests against stage deployment:
 
 .. code-block:: console
 
-  THOTH_USER_API_HOST=stage.thoth-station.ninja THOTH_MANAGEMENT_API_HOST=management.test.thoth-station.ninja ./test.sh
+  THOTH_USER_API_HOST=stage.thoth-station.ninja THOTH_MANAGEMENT_API_HOST=management.stage.thoth-station.ninja ./test.sh
 
 Run integration tests against test deployment (default behaviour):
 

--- a/README.rst
+++ b/README.rst
@@ -25,10 +25,10 @@ Run integration tests against stage deployment:
 
 .. code-block:: console
 
-  THOTH_USER_API_URL=stage.thoth-station.ninja ./test.sh
+  THOTH_USER_API_HOST=stage.thoth-station.ninja THOTH_MANAGEMENT_API_HOST=management.test.thoth-station.ninja ./test.sh
 
 Run integration tests against test deployment (default behaviour):
 
 .. code-block:: console
 
-  THOTH_USER_API_URL=test.thoth-station.ninja ./test.sh
+  THOTH_USER_API_HOST=test.thoth-station.ninja THOTH_MANAGEMENT_API_HOST=management.test.thoth-station.ninja ./test.sh

--- a/features/package_metadata.feature
+++ b/features/package_metadata.feature
@@ -1,13 +1,12 @@
 Feature: Querying Thoth for Python package metadata
     Scenario: Querying for the known Python Package Indices
         Given deployment is accessible using HTTPS
-        When I query for the list of known Python Package indices,
+        When I query for the list of known Python Package indices
         Then I should get a list of "2"
 
     Scenario Outline: Query for different indices for TensorFlow
         Given deployment is accessible using HTTPS
         And I query Thoth User API for "<index>" "<package>" "<version>"
-        When I execute the query
         Then I should get "<author>" and "<maintainer>"
 
         Examples: Packages

--- a/features/package_metadata.feature
+++ b/features/package_metadata.feature
@@ -4,9 +4,9 @@ Feature: Querying Thoth for Python package metadata
         When I query for the list of known Python Package indices
         Then I should get a list of "2"
 
-    Scenario Outline: Query for different indices for TensorFlow
+    Scenario Outline: Query for metadata for different indices for TensorFlow
         Given deployment is accessible using HTTPS
-        And I query Thoth User API for "<index>" "<package>" "<version>"
+        When I query Thoth User API for metadata about "<index>" "<package>" "<version>"
         Then I should get "<author>" and "<maintainer>"
 
         Examples: Packages

--- a/features/package_versions_solved.feature
+++ b/features/package_versions_solved.feature
@@ -6,5 +6,6 @@ Feature: Querying Thoth for Python package versions solved for all solvers
             | setuptools   |
         And number of versions for each package_name is available
         And deployment is accessible using HTTPS
+        And number of solvers available is provided
         When I query for the solved packages for the package_name from PyPI in Thoth Knowledge Graph
         Then I should get the same number provided from PyPI

--- a/features/solvers.feature
+++ b/features/solvers.feature
@@ -1,0 +1,10 @@
+Feature: Check for solvers available in Thoth
+    Scenario: Check there are minimum solvers available in Thoth
+        Given a set of solvers
+            | name |
+            | solver-rhel-8-py36 |
+            | solver-fedora-31-py37 |
+            | solver-fedora-31-py38 |
+
+        When we ask if the solver is available
+        Then we should find the solver available

--- a/features/solvers.feature
+++ b/features/solvers.feature
@@ -5,6 +5,6 @@ Feature: Check for solvers available in Thoth
             | solver-rhel-8-py36 |
             | solver-fedora-31-py37 |
             | solver-fedora-31-py38 |
-
+        And deployment is accessible using HTTPS
         When we ask if the solver is available
         Then we should find the solver available

--- a/features/solvers.feature
+++ b/features/solvers.feature
@@ -1,10 +1,10 @@
-Feature: Check for solvers available in Thoth
+Feature: Check for minimum solvers available in Thoth
     Scenario: Check there are minimum solvers available in Thoth
-        Given a set of solvers
+        Given deployment is accessible using HTTPS
+        And a minimum set of solvers requested
             | solver_name |
             | solver-rhel-8-py36 |
             | solver-fedora-31-py37 |
             | solver-fedora-31-py38 |
-        And deployment is accessible using HTTPS
         When we ask for the available solvers
-        Then they should include at least the given solvers
+        Then they should include at least the minimum set of solvers

--- a/features/solvers.feature
+++ b/features/solvers.feature
@@ -1,7 +1,7 @@
 Feature: Check for solvers available in Thoth
     Scenario: Check there are minimum solvers available in Thoth
         Given a set of solvers
-            | name |
+            | solver_name |
             | solver-rhel-8-py36 |
             | solver-fedora-31-py37 |
             | solver-fedora-31-py38 |

--- a/features/solvers.feature
+++ b/features/solvers.feature
@@ -6,5 +6,5 @@ Feature: Check for solvers available in Thoth
             | solver-fedora-31-py37 |
             | solver-fedora-31-py38 |
         And deployment is accessible using HTTPS
-        When we ask if the solver is available
-        Then we should find the solver available
+        When we ask for the available solvers
+        Then they should include at least the given solvers

--- a/features/steps/basic.py
+++ b/features/steps/basic.py
@@ -34,15 +34,25 @@ def deployment_accessible(context, scheme):
     if scheme not in ("HTTPS", "HTTP"):
         raise ValueError(f"Invalid scheme {scheme!r}, has to be HTTP or HTTPS")
 
-    context.api_url = os.environ["THOTH_USER_API_URL"]
+    context.user_api_url = os.environ["THOTH_USER_API_URL"]
+
     context.scheme = scheme.lower()
-    response = requests.get(f"{context.scheme}://{context.api_url}/api/v1", verify=False)
+    response = requests.get(f"{context.scheme}://{context.user_api_url}/api/v1", verify=False)
 
     assert (
         response.status_code == 200
     ), f"Invalid response when accessing User API /api/v1 endpoint: {response.status_code!r}"
 
     assert response.text, "Empty response from server for User API /api/v1 endpoint"
+
+    context.management_api_url = os.environ["THOTH_MANAGEMENT_API_URL"]
+    response = requests.get(f"{context.scheme}://{context.management_api_url}/api/v1", verify=False)
+
+    assert (
+        response.status_code == 200
+    ), f"Invalid response whn accessing Management API /api/v1 endpoint: {response.status_code!r}"
+
+    assert response.text, "Empty response from server for Management API /api/v1 endpoint"
 
 
 @when("thamos advise is run for {case} for recommendation type {recommendation_type} asynchronously")
@@ -54,7 +64,7 @@ def thamos_advise(context, case, recommendation_type):
     with open(f"features/data/{case}/Pipfile") as case_pipfile:
         pipfile = case_pipfile.read()
 
-    config.explicit_host = context.api_url
+    config.explicit_host = context.user_api_url
     config.tls_verify = False
 
     context.analysis_id = advise(
@@ -85,7 +95,8 @@ def wait_for_adviser_to_finish(context):
             raise RuntimeError("Adviser analysis took too much time to finish")
 
         response = requests.get(
-            f"{context.scheme}://{context.api_url}/api/v1/advise/python/{context.analysis_id}/status", verify=False,
+            f"{context.scheme}://{context.user_api_url}/api/v1/"
+            f"advise/python/{context.analysis_id}/status", verify=False,
         )
         assert response.status_code == 200
         exit_code = response.json()["status"]["exit_code"]
@@ -104,11 +115,11 @@ def wait_for_adviser_to_finish(context):
 def retrieve_advise_respond(context):
     """Retrieve analysis from Thoth using User API."""
     response = requests.get(
-        f"{context.scheme}://{context.api_url}/api/v1/advise/python/{context.analysis_id}", verify=False,
+        f"{context.scheme}://{context.user_api_url}/api/v1/advise/python/{context.analysis_id}", verify=False,
     )
     assert (
         response.status_code == 200
-    ), f"Bad status code ({response.status_code}) when obtaining adviser result from {context.api_url}"
+    ), f"Bad status code ({response.status_code}) when obtaining adviser result from {context.user_api_url}"
     context.adviser_result = response.json()
 
 

--- a/features/steps/basic.py
+++ b/features/steps/basic.py
@@ -50,7 +50,7 @@ def deployment_accessible(context, scheme):
 
     assert (
         response.status_code == 200
-    ), f"Invalid response whn accessing Management API /api/v1 endpoint: {response.status_code!r}"
+    ), f"Invalid response when accessing Management API /api/v1 endpoint: {response.status_code!r}"
 
     assert response.text, "Empty response from server for Management API /api/v1 endpoint"
 

--- a/features/steps/basic.py
+++ b/features/steps/basic.py
@@ -45,8 +45,8 @@ def deployment_accessible(context, scheme):
 
     assert response.text, "Empty response from server for User API /api/v1 endpoint"
 
-    context.management_api_url = os.environ["THOTH_MANAGEMENT_API_URL"]
-    response = requests.get(f"{context.scheme}://{context.management_api_url}/api/v1", verify=False)
+    context.management_api_host = os.environ["THOTH_MANAGEMENT_API_HOST"]
+    response = requests.get(f"{context.scheme}://{context.management_api_host}/api/v1", verify=False)
 
     assert (
         response.status_code == 200

--- a/features/steps/basic.py
+++ b/features/steps/basic.py
@@ -34,10 +34,10 @@ def deployment_accessible(context, scheme):
     if scheme not in ("HTTPS", "HTTP"):
         raise ValueError(f"Invalid scheme {scheme!r}, has to be HTTP or HTTPS")
 
-    context.user_api_url = os.environ["THOTH_USER_API_URL"]
+    context.user_api_host = os.environ["THOTH_USER_API_HOST"]
 
     context.scheme = scheme.lower()
-    response = requests.get(f"{context.scheme}://{context.user_api_url}/api/v1", verify=False)
+    response = requests.get(f"{context.scheme}://{context.user_api_host}/api/v1", verify=False)
 
     assert (
         response.status_code == 200
@@ -64,7 +64,7 @@ def thamos_advise(context, case, recommendation_type):
     with open(f"features/data/{case}/Pipfile") as case_pipfile:
         pipfile = case_pipfile.read()
 
-    config.explicit_host = context.user_api_url
+    config.explicit_host = context.user_api_host
     config.tls_verify = False
 
     context.analysis_id = advise(
@@ -95,7 +95,7 @@ def wait_for_adviser_to_finish(context):
             raise RuntimeError("Adviser analysis took too much time to finish")
 
         response = requests.get(
-            f"{context.scheme}://{context.user_api_url}/api/v1/"
+            f"{context.scheme}://{context.user_api_host}/api/v1/"
             f"advise/python/{context.analysis_id}/status", verify=False,
         )
         assert response.status_code == 200
@@ -115,11 +115,11 @@ def wait_for_adviser_to_finish(context):
 def retrieve_advise_respond(context):
     """Retrieve analysis from Thoth using User API."""
     response = requests.get(
-        f"{context.scheme}://{context.user_api_url}/api/v1/advise/python/{context.analysis_id}", verify=False,
+        f"{context.scheme}://{context.user_api_host}/api/v1/advise/python/{context.analysis_id}", verify=False,
     )
     assert (
         response.status_code == 200
-    ), f"Bad status code ({response.status_code}) when obtaining adviser result from {context.user_api_url}"
+    ), f"Bad status code ({response.status_code}) when obtaining adviser result from {context.user_api_host}"
     context.adviser_result = response.json()
 
 

--- a/features/steps/environment.py
+++ b/features/steps/environment.py
@@ -28,10 +28,10 @@ from hamcrest import assert_that, equal_to, greater_than
 @when('I query the list of "{kind}" environments')
 def step_impl(context, kind: str):
     """Retrieve list of Environments of given kind."""
-    response = requests.get(f"{context.scheme}://{context.user_api_url}/api/v1/{kind}-environment", verify=False,)
+    response = requests.get(f"{context.scheme}://{context.user_api_host}/api/v1/{kind}-environment", verify=False,)
     assert (
         response.status_code == 200
-    ), f"Bad status code ({response.status_code}) when obtaining {kind}-environement from {context.user_api_url}"
+    ), f"Bad status code ({response.status_code}) when obtaining {kind}-environement from {context.user_api_host}"
     context.result = response.json()
 
 

--- a/features/steps/environment.py
+++ b/features/steps/environment.py
@@ -28,10 +28,10 @@ from hamcrest import assert_that, equal_to, greater_than
 @when('I query the list of "{kind}" environments')
 def step_impl(context, kind: str):
     """Retrieve list of Environments of given kind."""
-    response = requests.get(f"{context.scheme}://{context.api_url}/api/v1/{kind}-environment", verify=False,)
+    response = requests.get(f"{context.scheme}://{context.user_api_url}/api/v1/{kind}-environment", verify=False,)
     assert (
         response.status_code == 200
-    ), f"Bad status code ({response.status_code}) when obtaining {kind}-environement from {context.api_url}"
+    ), f"Bad status code ({response.status_code}) when obtaining {kind}-environement from {context.user_api_url}"
     context.result = response.json()
 
 

--- a/features/steps/index.py
+++ b/features/steps/index.py
@@ -28,17 +28,17 @@ from hamcrest import assert_that, equal_to
 @given('I query Thoth User API for "{index}" "{package}" "{version}"')
 def step_impl(context, index: str, package: str, version: str):
     """Retrieve metadata about Python Package."""
-    context.query_string = f"{context.scheme}://{context.api_url}/api/v1/python/package/metadata" + \
-        f"?index={urllib.parse.quote_plus(index)}&name={package}&version={version}"
+    context.query_string = f"{context.scheme}://{context.user_api_url}/api/v1/"
+    f"python/package/metadata?index={urllib.parse.quote_plus(index)}&name={package}&version={version}"
 
 
 @when("I query for the list of known Python Package indices,")
 def step_impl(context):
     """Retrieve list of Python Package Indices known to Thoth."""
-    response = requests.get(f"{context.scheme}://{context.api_url}/api/v1/python-package-index", verify=False,)
+    response = requests.get(f"{context.scheme}://{context.user_api_url}/api/v1/python-package-index", verify=False,)
     assert (
         response.status_code == 200
-    ), f"Bad status code ({response.status_code}) when obtaining python-package-index from {context.api_url}"
+    ), f"Bad status code ({response.status_code}) when obtaining python-package-index from {context.user_api_url}"
     context.result = response.json()
 
 

--- a/features/steps/index.py
+++ b/features/steps/index.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Basic integration tests for Thoth deployment."""
+"""Thoth indices integration test for Thoth deployment."""
 
 import os
 import requests
@@ -25,42 +25,18 @@ from behave import given, when, then
 from hamcrest import assert_that, equal_to
 
 
-@given('I query Thoth User API for "{index}" "{package}" "{version}"')
-def step_impl(context, index: str, package: str, version: str):
-    """Retrieve metadata about Python Package."""
-    context.query_string = f"{context.scheme}://{context.user_api_url}/api/v1/"
-    f"python/package/metadata?index={urllib.parse.quote_plus(index)}&name={package}&version={version}"
-
-
-@when("I query for the list of known Python Package indices,")
+@when("I query for the list of known Python Package indices")
 def step_impl(context):
     """Retrieve list of Python Package Indices known to Thoth."""
+    context.result = {}
     response = requests.get(f"{context.scheme}://{context.user_api_url}/api/v1/python-package-index", verify=False,)
     assert (
         response.status_code == 200
     ), f"Bad status code ({response.status_code}) when obtaining python-package-index from {context.user_api_url}"
-    context.result = response.json()
-
-
-@when("I execute the query")
-def step_impl(context):
-    """Execute the prepared query."""
-    response = requests.get(f"{context.query_string}", verify=False,)
-    assert (
-        response.status_code == 200
-    ), f"Bad status code ({response.status_code}) when executing the query: {context.query_string}"
-
-    context.result = response.json()
-
-
-@then('I should get "{author}" and "{maintainer}"')
-def step_impl(context, author: str, maintainer: str):
-    """Verify conditions for author and maintainer."""
-    assert_that(context.result["author"], equal_to(author))
-    assert_that(context.result["maintainer"], equal_to(maintainer))
+    context.result["indices"] = response.json()
 
 
 @then('I should get a list of "{number}"')
 def step_impl(context, number: int):
     """Verify correct number is retrieved."""
-    assert_that(len(context.result), equal_to(int(number)))
+    assert_that(len(context.result["indices"]), equal_to(int(number)))

--- a/features/steps/index.py
+++ b/features/steps/index.py
@@ -29,10 +29,10 @@ from hamcrest import assert_that, equal_to
 def step_impl(context):
     """Retrieve list of Python Package Indices known to Thoth."""
     context.result = {}
-    response = requests.get(f"{context.scheme}://{context.user_api_url}/api/v1/python-package-index", verify=False,)
+    response = requests.get(f"{context.scheme}://{context.user_api_host}/api/v1/python-package-index", verify=False,)
     assert (
         response.status_code == 200
-    ), f"Bad status code ({response.status_code}) when obtaining python-package-index from {context.user_api_url}"
+    ), f"Bad status code ({response.status_code}) when obtaining python-package-index from {context.user_api_host}"
     context.result["indices"] = response.json()
 
 

--- a/features/steps/python_package_metadata.py
+++ b/features/steps/python_package_metadata.py
@@ -25,11 +25,15 @@ from behave import given, when, then
 from hamcrest import assert_that, equal_to
 
 
-@given('I query Thoth User API for "{index}" "{package}" "{version}"')
+@when('I query Thoth User API for metadata about "{index}" "{package}" "{version}"')
 def step_impl(context, index: str, package: str, version: str):
     """Retrieve metadata about Python Package."""
     payload = {"index": index, "name": package, "version": version}
-    response = requests.get(f"{context.scheme}://{context.user_api_url}/api/v1/python/package/metadata", verify=False, params=payload)
+    response = requests.get(
+        f"{context.scheme}://{context.user_api_url}/api/v1/python/package/metadata",
+        verify=False,
+        params=payload
+    )
     assert (
             response.status_code == 200
         ), f"Bad status code ({response.status_code}) when obtaining python-package-index from {context.user_api_url}"

--- a/features/steps/python_package_metadata.py
+++ b/features/steps/python_package_metadata.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# Thoth's integration tests
+# Copyright(C) 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Python Package Metadata integration test for Thoth deployment."""
+
+import os
+import requests
+import urllib.parse
+
+from behave import given, when, then
+from hamcrest import assert_that, equal_to
+
+
+@given('I query Thoth User API for "{index}" "{package}" "{version}"')
+def step_impl(context, index: str, package: str, version: str):
+    """Retrieve metadata about Python Package."""
+    payload = {"index": index, "name": package, "version": version}
+    response = requests.get(f"{context.scheme}://{context.user_api_url}/api/v1/python/package/metadata", verify=False, params=payload)
+    assert (
+            response.status_code == 200
+        ), f"Bad status code ({response.status_code}) when obtaining python-package-index from {context.user_api_url}"
+    context.result = response.json()
+
+
+@then('I should get "{author}" and "{maintainer}"')
+def step_impl(context, author: str, maintainer: str):
+    """Verify conditions for author and maintainer."""
+    assert_that(context.result["author"], equal_to(author))
+    assert_that(str(context.result["maintainer"]), equal_to(maintainer))

--- a/features/steps/python_package_metadata.py
+++ b/features/steps/python_package_metadata.py
@@ -30,13 +30,13 @@ def step_impl(context, index: str, package: str, version: str):
     """Retrieve metadata about Python Package."""
     payload = {"index": index, "name": package, "version": version}
     response = requests.get(
-        f"{context.scheme}://{context.user_api_url}/api/v1/python/package/metadata",
+        f"{context.scheme}://{context.user_api_host}/api/v1/python/package/metadata",
         verify=False,
         params=payload
     )
     assert (
             response.status_code == 200
-        ), f"Bad status code ({response.status_code}) when obtaining python-package-index from {context.user_api_url}"
+        ), f"Bad status code ({response.status_code}) when obtaining python-package-index from {context.user_api_host}"
     context.result = response.json()
 
 

--- a/features/steps/python_package_solved.py
+++ b/features/steps/python_package_solved.py
@@ -49,7 +49,7 @@ def step_impl(context):
 @given("number of solvers available is provided")
 def step_impl(context):
     """Get number of solver available in Thoth."""
-    url = f"{context.scheme}://{context.management_api_url}/api/v1/solvers"
+    url = f"{context.scheme}://{context.management_api_host}/api/v1/solvers"
     data = requests.get(url).json()
     available_solvers = [str(solver["solver_name"]) for solver in data["solvers"]["python"]]
     context.solvers_number = len(available_solvers)

--- a/features/steps/python_package_solved.py
+++ b/features/steps/python_package_solved.py
@@ -61,7 +61,7 @@ def step_impl(context):
     for package in context.result.keys():
         payload = {'name': package}
         response = requests.get(
-            f"{context.scheme}://{context.user_api_url}/api/v1/python/packages/count", params=payload)
+            f"{context.scheme}://{context.user_api_host}/api/v1/python/packages/count", params=payload)
         context.result[package]["number_thoth"] = response.json()["count"]
         context.result[package]["number_pypi"] = context.result[package]["number_pypi"]*context.solvers_number
 

--- a/features/steps/solvers.py
+++ b/features/steps/solvers.py
@@ -34,7 +34,7 @@ def step_impl(context):
     context.result["requested_solvers"] = requested_solvers
 
 
-@when(u'we ask if the solver is available')
+@when(u'we ask if the solvers are available')
 def step_impl(context):
     """Retrieve available solvers."""
     url = f"{context.scheme}://{context.management_api_url}/api/v1/solvers"
@@ -43,7 +43,7 @@ def step_impl(context):
     context.result["available_solvers"] = available_solvers
 
 
-@then(u'we should find the solver available')
+@then(u'we should find the solvers available')
 def step_impl(context):
     """Verify all requested solvers are available."""
     print(context.result)

--- a/features/steps/solvers.py
+++ b/features/steps/solvers.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# Thoth's integration tests
+# Copyright(C) 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Integration tests for Thoth deployment for solvers available."""
+
+@given(u'a set of solvers')
+def step_impl(context):
+    raise NotImplementedError(u'STEP: Given a set of solvers')
+
+
+@when(u'we ask if the solver is available')
+def step_impl(context):
+    raise NotImplementedError(u'STEP: When we ask if the solver is available')
+
+
+@then(u'we should find the solver available')
+def step_impl(context):
+    raise NotImplementedError(u'STEP: Then we should find the solver available')

--- a/features/steps/solvers.py
+++ b/features/steps/solvers.py
@@ -17,16 +17,34 @@
 
 """Integration tests for Thoth deployment for solvers available."""
 
+import os
+import requests
+
+from behave import given, when, then
+from hamcrest import assert_that, contains_inanyorder
+
+
 @given(u'a set of solvers')
 def step_impl(context):
-    raise NotImplementedError(u'STEP: Given a set of solvers')
+    """Take list of solvers from table."""
+    context.result = {}
+    requested_solvers = []
+    for row in context.table:
+        requested_solvers.append(row["solver_name"])
+    context.result["requested_solvers"] = requested_solvers
 
 
 @when(u'we ask if the solver is available')
 def step_impl(context):
-    raise NotImplementedError(u'STEP: When we ask if the solver is available')
+    """Retrieve available solvers."""
+    url = f"{context.scheme}://{context.management_api_url}/api/v1/solvers"
+    data = requests.get(url).json()
+    available_solvers = [str(solver["solver_name"]) for solver in data["solvers"]["python"]]
+    context.result["available_solvers"] = available_solvers
 
 
 @then(u'we should find the solver available')
 def step_impl(context):
-    raise NotImplementedError(u'STEP: Then we should find the solver available')
+    """Verify all requested solvers are available."""
+    print(context.result)
+    assert_that(context.result["available_solvers"], contains_inanyorder(context.result["requested_solvers"]))

--- a/features/steps/solvers.py
+++ b/features/steps/solvers.py
@@ -34,7 +34,7 @@ def step_impl(context):
     context.result["requested_solvers"] = requested_solvers
 
 
-@when(u'we ask if the solvers are available')
+@when(u'we ask for the available solvers')
 def step_impl(context):
     """Retrieve available solvers."""
     url = f"{context.scheme}://{context.management_api_url}/api/v1/solvers"
@@ -43,7 +43,7 @@ def step_impl(context):
     context.result["available_solvers"] = available_solvers
 
 
-@then(u'we should find the solvers available')
+@then(u'they should include at least the given solvers')
 def step_impl(context):
     """Verify all requested solvers are available."""
     print(context.result)

--- a/features/steps/solvers.py
+++ b/features/steps/solvers.py
@@ -24,7 +24,7 @@ from behave import given, when, then
 from hamcrest import assert_that, contains_inanyorder
 
 
-@given(u'a set of solvers')
+@given(u'a minimum set of solvers requested')
 def step_impl(context):
     """Take list of solvers from table."""
     context.result = {}
@@ -37,13 +37,13 @@ def step_impl(context):
 @when(u'we ask for the available solvers')
 def step_impl(context):
     """Retrieve available solvers."""
-    url = f"{context.scheme}://{context.management_api_url}/api/v1/solvers"
+    url = f"{context.scheme}://{context.management_api_host}/api/v1/solvers"
     data = requests.get(url).json()
     available_solvers = [str(solver["solver_name"]) for solver in data["solvers"]["python"]]
     context.result["available_solvers"] = available_solvers
 
 
-@then(u'they should include at least the given solvers')
+@then(u'they should include at least the minimum set of solvers')
 def step_impl(context):
     """Verify all requested solvers are available."""
     print(context.result)

--- a/features/steps/solvers.py
+++ b/features/steps/solvers.py
@@ -21,7 +21,7 @@ import os
 import requests
 
 from behave import given, when, then
-from hamcrest import assert_that, contains_inanyorder
+from hamcrest import assert_that, has_item
 
 
 @given(u'a minimum set of solvers requested')
@@ -47,4 +47,7 @@ def step_impl(context):
 def step_impl(context):
     """Verify all requested solvers are available."""
     print(context.result)
-    assert_that(context.result["available_solvers"], contains_inanyorder(context.result["requested_solvers"]))
+    requested_solvers = context.result["requested_solvers"]
+    available_solvers = context.result["available_solvers"]
+    for r_s in requested_solvers:
+        assert_that(available_solvers, has_item(r_s))

--- a/test.sh
+++ b/test.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-THOTH_USER_API_URL=${THOTH_USER_API_URL:-test.thoth-station.ninja}
+THOTH_USER_API_HOST=${THOTH_USER_API_HOST:-test.thoth-station.ninja}
 
 echo -e "------------------------------------------------------------------\n\n"
-echo "> Tests are executed against User API at $THOTH_USER_API_URL"
+echo "> Tests are executed against User API at $THOTH_USER_API_HOST"
 echo -e "\n\n------------------------------------------------------------------\n\n"
-export THOTH_USER_API_URL
+export THOTH_USER_API_HOST
 [[ $NO_INSTALL -eq "1" ]] || pipenv install --deploy
 pipenv run behave --show-timings


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

This PR:
- Introduces integration test for solvers
- Splits `api_url` in `user_api_url` and `management_api_url`
- Fixes: https://github.com/thoth-station/integration-tests/issues/8
- Refactor previous integration-tests
- split index and package metadata to facilitate interpretations of tests for each statement