### PR TITLE
Package Indices should be atleast 2 in deployment

### DIFF
--- a/features/package_metadata.feature
+++ b/features/package_metadata.feature
@@ -2,7 +2,7 @@ Feature: Querying Thoth for Python package metadata
     Scenario: Querying for the known Python Package Indices
         Given deployment is accessible using HTTPS
         When I query for the list of known Python Package indices
-        Then I should get a list of "2"
+        Then I should get a list of at least "2" Python Package indices
 
     Scenario Outline: Query for metadata for different indices for TensorFlow
         Given deployment is accessible using HTTPS

--- a/features/steps/index.py
+++ b/features/steps/index.py
@@ -22,7 +22,7 @@
 import requests
 
 from behave import when, then
-from hamcrest import assert_that, equal_to
+from hamcrest import assert_that, greater_than_or_equal_to
 
 
 @when("I query for the list of known Python Package indices")
@@ -36,7 +36,7 @@ def step_impl(context):
     context.result["indices"] = response.json()
 
 
-@then('I should get a list of "{number}"')
+@then('I should get a list of at least "{number}" Python Package indices')
 def step_impl(context, number: int):
     """Verify correct number is retrieved."""
-    assert_that(len(context.result["indices"]), equal_to(int(number)))
+    assert_that(len(context.result["indices"]), greater_than_or_equal_to(int(number)))


### PR DESCRIPTION
Related Issue:
![indices](https://user-images.githubusercontent.com/14028058/95254055-f10aaa00-083c-11eb-8f26-9cf687686168.png)
related-to: #47 

Resulted execution:
![indices-1](https://user-images.githubusercontent.com/14028058/95254337-5e1e3f80-083d-11eb-8942-f1a4b41ae328.png)

Package Indices should be at least 2 in the deployment
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>