### PR TITLE
check solver names match a pattern

### DIFF
--- a/features/solvers.feature
+++ b/features/solvers.feature
@@ -1,12 +1,5 @@
 Feature: Check for minimum solvers available in Thoth
     Scenario: Check there are minimum solvers available in Thoth
         Given deployment is accessible using HTTPS
-        And a minimum set of solvers requested
-            | solver_name |
-            | solver-rhel-8-py36 |
-            | solver-fedora-31-py37 |
-            | solver-fedora-31-py38 |
-            | solver-fedora-32-py37 |
-            | solver-fedora-32-py38 |
         When we ask for the available solvers
         Then they should include at least the minimum set of solvers

--- a/features/steps/basic.py
+++ b/features/steps/basic.py
@@ -34,6 +34,8 @@ def deployment_accessible(context, scheme):
     if scheme not in ("HTTPS", "HTTP"):
         raise ValueError(f"Invalid scheme {scheme!r}, has to be HTTP or HTTPS")
 
+    context.result = {}
+
     context.user_api_host = os.environ["THOTH_USER_API_HOST"]
 
     context.scheme = scheme.lower()

--- a/features/steps/solvers.py
+++ b/features/steps/solvers.py
@@ -20,19 +20,9 @@
 
 
 import requests
+import re
 
-from behave import given, when, then
-from hamcrest import assert_that, has_item
-
-
-@given("a minimum set of solvers requested")
-def step_impl(context):
-    """Take list of solvers from table."""
-    context.result = {}
-    requested_solvers = []
-    for row in context.table:
-        requested_solvers.append(row["solver_name"])
-    context.result["requested_solvers"] = requested_solvers
+from behave import when, then
 
 
 @when("we ask for the available solvers")
@@ -47,8 +37,6 @@ def step_impl(context):
 @then("they should include at least the minimum set of solvers")
 def step_impl(context):
     """Verify all requested solvers are available."""
-    print(context.result)
-    requested_solvers = context.result["requested_solvers"]
     available_solvers = context.result["available_solvers"]
-    for r_s in requested_solvers:
-        assert_that(available_solvers, has_item(r_s))
+    for a_s in available_solvers:
+        assert re.match("solver-(rhel|fedora)-.*\d-py3\d", a_s)  # noqa: W605


### PR DESCRIPTION
Instead of having a minimum set of solvers requested, let's get all available solvers and check they match some pattern like Solver-`solver-{rhel|fedora}-{num}-py3{num}`.