### PR TITLE
Allow passing parameters to behave runs

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -14,4 +14,4 @@ export PIPENV_HIDE_EMOJIS=1
 export PIPENV_COLORBLIND=1
 
 [[ $NO_INSTALL -eq "1" ]] || pipenv install --deploy
-pipenv --verbose run behave --tags=~@local-test-only --show-timings
+pipenv --verbose run behave --tags=~@local-test-only --show-timings $@


### PR DESCRIPTION
## Related Issues and Dependencies

Allow parametrizing behave tests. With this change, one can run specific features using:

```console
test.sh -i solvers.feature
```

Or pass any other options to the underlying behave.

## This introduces a breaking change

- [x] No
