### PR TITLE
Send integration test results via e-mail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ venv.bak/
 .mypy_cache/
 .vscode/
 .thoth_last_analysis_id
+behave-report.html

--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ requests = "*"
 pyhamcrest = "*"
 thoth-storages = "*"
 amun = "*"
+behave-html-formatter = "*"
 
 [requires]
-python_version = "3.6"
+python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "cd8b2708b00f376ac13dd64cbfa8cde91a65381521c4cccf91ca4f2a440d57ea"
+            "sha256": "f36ffe45d4eebf9d191d3a5ad33190fc360290b8c522eb8cb3012b81df0e4096"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.6"
+            "python_version": "3.8"
         },
         "sources": [
             {
@@ -120,21 +120,29 @@
             "index": "pypi",
             "version": "==1.2.6"
         },
+        "behave-html-formatter": {
+            "hashes": [
+                "sha256:2a0e8f104c3cadbbd851e41fd9e599a29c91e3a867e327b5b96515a0894406b1",
+                "sha256:5fd92eee436047a9532d8d7f3ba385413051087fd40c36e8b0f3bd6f0297ecf9"
+            ],
+            "index": "pypi",
+            "version": "==0.9.6"
+        },
         "boto3": {
             "hashes": [
-                "sha256:0d126d429a8a9ea2c8409a1ee36ce5a34e11db788d7730a714016264f10bbb89",
-                "sha256:d6aafb804fca2b67c65dda78ad8b4afed901e004071208b84c804d345ad9ebba"
+                "sha256:bb2e16b0b8c13d47bc5d7b64a90bfa1310f4f2b524bdd3dcfe9237ddf243554d",
+                "sha256:f9d940f40c0302493466a20e716a23fa942b8e865dda4ebbca5e4fa3f5ca9635"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.17.5"
+            "version": "==1.17.6"
         },
         "botocore": {
             "hashes": [
-                "sha256:04a1df759681f5f171accb354d863bfed0774d64a4e8ee35ff49835755660a4e",
-                "sha256:3c55f0db5e08920727f4fa24a87aed60060643f4b0b5665c62ec762f79e82d6b"
+                "sha256:39832e4732fcdc897e1b1a50474251c7d3218029a902634a876364c223ca2432",
+                "sha256:7d04cd042ac01e08463dcbe520835d02f414ba431a43e4b4035bd2d0531b66a0"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.20.5"
+            "version": "==1.20.6"
         },
         "cachetools": {
             "hashes": [
@@ -153,45 +161,45 @@
         },
         "cffi": {
             "hashes": [
-                "sha256:00a1ba5e2e95684448de9b89888ccd02c98d512064b4cb987d48f4b40aa0421e",
-                "sha256:00e28066507bfc3fe865a31f325c8391a1ac2916219340f87dfad602c3e48e5d",
-                "sha256:045d792900a75e8b1e1b0ab6787dd733a8190ffcf80e8c8ceb2fb10a29ff238a",
-                "sha256:0638c3ae1a0edfb77c6765d487fee624d2b1ee1bdfeffc1f0b58c64d149e7eec",
-                "sha256:105abaf8a6075dc96c1fe5ae7aae073f4696f2905fde6aeada4c9d2926752362",
-                "sha256:155136b51fd733fa94e1c2ea5211dcd4c8879869008fc811648f16541bf99668",
-                "sha256:1a465cbe98a7fd391d47dce4b8f7e5b921e6cd805ef421d04f5f66ba8f06086c",
-                "sha256:1d2c4994f515e5b485fd6d3a73d05526aa0fcf248eb135996b088d25dfa1865b",
-                "sha256:2c24d61263f511551f740d1a065eb0212db1dbbbbd241db758f5244281590c06",
-                "sha256:51a8b381b16ddd370178a65360ebe15fbc1c71cf6f584613a7ea08bfad946698",
-                "sha256:594234691ac0e9b770aee9fcdb8fa02c22e43e5c619456efd0d6c2bf276f3eb2",
-                "sha256:5cf4be6c304ad0b6602f5c4e90e2f59b47653ac1ed9c662ed379fe48a8f26b0c",
-                "sha256:64081b3f8f6f3c3de6191ec89d7dc6c86a8a43911f7ecb422c60e90c70be41c7",
-                "sha256:6bc25fc545a6b3d57b5f8618e59fc13d3a3a68431e8ca5fd4c13241cd70d0009",
-                "sha256:798caa2a2384b1cbe8a2a139d80734c9db54f9cc155c99d7cc92441a23871c03",
-                "sha256:7c6b1dece89874d9541fc974917b631406233ea0440d0bdfbb8e03bf39a49b3b",
-                "sha256:7ef7d4ced6b325e92eb4d3502946c78c5367bc416398d387b39591532536734e",
-                "sha256:840793c68105fe031f34d6a086eaea153a0cd5c491cde82a74b420edd0a2b909",
-                "sha256:8d6603078baf4e11edc4168a514c5ce5b3ba6e3e9c374298cb88437957960a53",
-                "sha256:9cc46bc107224ff5b6d04369e7c595acb700c3613ad7bcf2e2012f62ece80c35",
-                "sha256:9f7a31251289b2ab6d4012f6e83e58bc3b96bd151f5b5262467f4bb6b34a7c26",
-                "sha256:9ffb888f19d54a4d4dfd4b3f29bc2c16aa4972f1c2ab9c4ab09b8ab8685b9c2b",
-                "sha256:a5ed8c05548b54b998b9498753fb9cadbfd92ee88e884641377d8a8b291bcc01",
-                "sha256:a7711edca4dcef1a75257b50a2fbfe92a65187c47dab5a0f1b9b332c5919a3fb",
-                "sha256:af5c59122a011049aad5dd87424b8e65a80e4a6477419c0c1015f73fb5ea0293",
-                "sha256:b18e0a9ef57d2b41f5c68beefa32317d286c3d6ac0484efd10d6e07491bb95dd",
-                "sha256:b4e248d1087abf9f4c10f3c398896c87ce82a9856494a7155823eb45a892395d",
-                "sha256:ba4e9e0ae13fc41c6b23299545e5ef73055213e466bd107953e4a013a5ddd7e3",
-                "sha256:c6332685306b6417a91b1ff9fae889b3ba65c2292d64bd9245c093b1b284809d",
-                "sha256:d5ff0621c88ce83a28a10d2ce719b2ee85635e85c515f12bac99a95306da4b2e",
-                "sha256:d9efd8b7a3ef378dd61a1e77367f1924375befc2eba06168b6ebfa903a5e59ca",
-                "sha256:df5169c4396adc04f9b0a05f13c074df878b6052430e03f50e68adf3a57aa28d",
-                "sha256:ebb253464a5d0482b191274f1c8bf00e33f7e0b9c66405fbffc61ed2c839c775",
-                "sha256:ec80dc47f54e6e9a78181ce05feb71a0353854cc26999db963695f950b5fb375",
-                "sha256:f032b34669220030f905152045dfa27741ce1a6db3324a5bc0b96b6c7420c87b",
-                "sha256:f60567825f791c6f8a592f3c6e3bd93dd2934e3f9dac189308426bd76b00ef3b",
-                "sha256:f803eaa94c2fcda012c047e62bc7a51b0bdabda1cad7a92a522694ea2d76e49f"
+                "sha256:005a36f41773e148deac64b08f233873a4d0c18b053d37da83f6af4d9087b813",
+                "sha256:0857f0ae312d855239a55c81ef453ee8fd24136eaba8e87a2eceba644c0d4c06",
+                "sha256:1071534bbbf8cbb31b498d5d9db0f274f2f7a865adca4ae429e147ba40f73dea",
+                "sha256:158d0d15119b4b7ff6b926536763dc0714313aa59e320ddf787502c70c4d4bee",
+                "sha256:1f436816fc868b098b0d63b8920de7d208c90a67212546d02f84fe78a9c26396",
+                "sha256:2894f2df484ff56d717bead0a5c2abb6b9d2bf26d6960c4604d5c48bbc30ee73",
+                "sha256:29314480e958fd8aab22e4a58b355b629c59bf5f2ac2492b61e3dc06d8c7a315",
+                "sha256:34eff4b97f3d982fb93e2831e6750127d1355a923ebaeeb565407b3d2f8d41a1",
+                "sha256:35f27e6eb43380fa080dccf676dece30bef72e4a67617ffda586641cd4508d49",
+                "sha256:3d3dd4c9e559eb172ecf00a2a7517e97d1e96de2a5e610bd9b68cea3925b4892",
+                "sha256:43e0b9d9e2c9e5d152946b9c5fe062c151614b262fda2e7b201204de0b99e482",
+                "sha256:48e1c69bbacfc3d932221851b39d49e81567a4d4aac3b21258d9c24578280058",
+                "sha256:51182f8927c5af975fece87b1b369f722c570fe169f9880764b1ee3bca8347b5",
+                "sha256:58e3f59d583d413809d60779492342801d6e82fefb89c86a38e040c16883be53",
+                "sha256:5de7970188bb46b7bf9858eb6890aad302577a5f6f75091fd7cdd3ef13ef3045",
+                "sha256:65fa59693c62cf06e45ddbb822165394a288edce9e276647f0046e1ec26920f3",
+                "sha256:69e395c24fc60aad6bb4fa7e583698ea6cc684648e1ffb7fe85e3c1ca131a7d5",
+                "sha256:6c97d7350133666fbb5cf4abdc1178c812cb205dc6f41d174a7b0f18fb93337e",
+                "sha256:6e4714cc64f474e4d6e37cfff31a814b509a35cb17de4fb1999907575684479c",
+                "sha256:72d8d3ef52c208ee1c7b2e341f7d71c6fd3157138abf1a95166e6165dd5d4369",
+                "sha256:8ae6299f6c68de06f136f1f9e69458eae58f1dacf10af5c17353eae03aa0d827",
+                "sha256:8b198cec6c72df5289c05b05b8b0969819783f9418e0409865dac47288d2a053",
+                "sha256:99cd03ae7988a93dd00bcd9d0b75e1f6c426063d6f03d2f90b89e29b25b82dfa",
+                "sha256:9cf8022fb8d07a97c178b02327b284521c7708d7c71a9c9c355c178ac4bbd3d4",
+                "sha256:9de2e279153a443c656f2defd67769e6d1e4163952b3c622dcea5b08a6405322",
+                "sha256:9e93e79c2551ff263400e1e4be085a1210e12073a31c2011dbbda14bda0c6132",
+                "sha256:9ff227395193126d82e60319a673a037d5de84633f11279e336f9c0f189ecc62",
+                "sha256:a465da611f6fa124963b91bf432d960a555563efe4ed1cc403ba5077b15370aa",
+                "sha256:ad17025d226ee5beec591b52800c11680fca3df50b8b29fe51d882576e039ee0",
+                "sha256:afb29c1ba2e5a3736f1c301d9d0abe3ec8b86957d04ddfa9d7a6a42b9367e396",
+                "sha256:b85eb46a81787c50650f2392b9b4ef23e1f126313b9e0e9013b35c15e4288e2e",
+                "sha256:bb89f306e5da99f4d922728ddcd6f7fcebb3241fc40edebcb7284d7514741991",
+                "sha256:cbde590d4faaa07c72bf979734738f328d239913ba3e043b1e98fe9a39f8b2b6",
+                "sha256:cd2868886d547469123fadc46eac7ea5253ea7fcb139f12e1dfc2bbd406427d1",
+                "sha256:d42b11d692e11b6634f7613ad8df5d6d5f8875f5d48939520d351007b3c13406",
+                "sha256:f2d45f97ab6bb54753eab54fffe75aaf3de4ff2341c9daee1987ee1837636f1d",
+                "sha256:fd78e5fee591709f32ef6edb9a015b4aa1a5022598e36227500c8f4e02328d9c"
             ],
-            "version": "==1.14.4"
+            "version": "==1.14.5"
         },
         "chardet": {
             "hashes": [
@@ -230,14 +238,6 @@
             ],
             "version": "==3.0.0"
         },
-        "dataclasses": {
-            "hashes": [
-                "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf",
-                "sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97"
-            ],
-            "markers": "python_version >= '3.6' and python_version < '3.7'",
-            "version": "==0.8"
-        },
         "delegator.py": {
             "hashes": [
                 "sha256:814657d96b98a244c479e3d5f6e9e850ac333e85f807d6bc846e72bbb2537806",
@@ -254,11 +254,11 @@
         },
         "google-auth": {
             "hashes": [
-                "sha256:008e23ed080674f69f9d2d7d80db4c2591b9bb307d136cea7b3bc129771d211d",
-                "sha256:514e39f4190ca972200ba33876da5a8857c5665f2b4ccc36c8b8ee21228aae80"
+                "sha256:1b461d079b5650efe492a7814e95c536ffa9e7a96e39a6d16189c1604f18554f",
+                "sha256:8ce6862cf4e9252de10045f05fa80393fde831da9c2b45c39288edeee3cde7f2"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.25.0"
+            "version": "==1.26.1"
         },
         "idna": {
             "hashes": [
@@ -267,21 +267,6 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
-        },
-        "idna-ssl": {
-            "hashes": [
-                "sha256:a933e3bb13da54383f9e8f35dc4f9cb9eb9b3b78c6b36f311254d6d0d92c6c7c"
-            ],
-            "markers": "python_version < '3.7'",
-            "version": "==1.1.0"
-        },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:ace61d5fc652dc280e7b6b4ff732a9c2d40db2c0f92bc6cb74e07b73d53a1771",
-                "sha256:fa5daa4477a7414ae34e95942e4dd07f62adf589143c875c133c1e53c4eff38d"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==3.4.0"
         },
         "invectio": {
             "hashes": [
@@ -833,10 +818,10 @@
         },
         "sentry-sdk": {
             "hashes": [
-                "sha256:0a711ec952441c2ec89b8f5d226c33bc697914f46e876b44a4edd3e7864cf4d0",
-                "sha256:737a094e49a529dd0fdcaafa9e97cf7c3d5eb964bd229821d640bc77f3502b3f"
+                "sha256:012f2c8f40a504e2d68d045f72a2fd63814acb61ea6db5014df75573077b5ceb",
+                "sha256:31871a1c18547cafa7b75064c6391aa517b15468fda7b644ccb149decccb9d44"
             ],
-            "version": "==0.19.5"
+            "version": "==0.20.0"
         },
         "six": {
             "hashes": [
@@ -963,7 +948,6 @@
                 "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c",
                 "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
             ],
-            "markers": "python_version < '3.8'",
             "version": "==3.7.4.3"
         },
         "tzlocal": {
@@ -1045,14 +1029,6 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==1.3.0"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108",
-                "sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.4.0"
         }
     },
     "develop": {}

--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,13 @@ The command above will trigger installation of all the necessary libraries and e
 * ``THOTH_AMUN_API_HOST`` - the HOST to deployment where Amun API sits
 * ``THOTH_MANAGEMENT_API_SECRET`` - the secret to schedule solver analysis
 * ``NO_INSTALL`` - do not install dependencies (expects that the `pipenv install` command was already issued)
+* ``SEND_EMAIL`` - if set to ``1``, an e-mail report is sent with integration test results
+
+  * ``THOTH_DEPLOYMENT_NAME`` - specifies deployment name used (shown in the subject)
+  * ``THOTH_EMAIL_SMTP_SERVER`` - SMTP server to be used for sending the e-mail
+  * ``THOTH_EMAIL_TO`` - e-mail recipient
+  * ``THOTH_EMAIL_FROM`` - sender configuration
+
 
 Examples
 ========

--- a/behave.ini
+++ b/behave.ini
@@ -1,0 +1,2 @@
+[behave.formatters]
+html = behave_html_formatter:HTMLFormatter

--- a/sendmail.py
+++ b/sendmail.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# Thoth's integration tests
+# Copyright(C) 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/
+
+"""Send e-mail report, used to send reports to our mailing list."""
+
+from datetime import date
+from email.mime.text import MIMEText
+import os
+import smtplib
+
+_BEHAVE_REPORT_FILE = "behave-report.html"
+_DEPLOYMENT_NAME = os.getenv("THOTH_DEPLOYMENT_NAME", "N/A")
+_EMAIL_SMTP_SERVER = os.getenv("THOTH_EMAIL_SMTP_SERVER", "smtp.corp.redhat.com")
+_EMAIL_TO = os.getenv("THOTH_EMAIL_TO", "fpokorny@redhat.com")
+_EMAIL_FROM = os.getenv("THOTH_EMAIL_FROM", "noreply@redhat.com")
+
+
+def _create_email_subject() -> str:
+    """Create e-mail subject."""
+    today = date.today()
+    return f"Integration tests update for {_DEPLOYMENT_NAME} ({today.strftime('%Y-%m-%d')})"
+
+
+def send_email() -> None:
+    """Send e-mail with begave test reports."""
+    with open(_BEHAVE_REPORT_FILE, 'r') as fp:
+        msg = MIMEText(fp.read(), "html")
+
+    msg['Subject'] = _create_email_subject()
+    msg['From'] = _EMAIL_FROM
+    msg['To'] = _EMAIL_TO
+
+    s = smtplib.SMTP(_EMAIL_SMTP_SERVER)
+    s.sendmail(msg['From'], [msg['To']], msg.as_string())
+    s.quit()
+
+
+__name__ == "__main__" and send_email()

--- a/sendmail.py
+++ b/sendmail.py
@@ -37,15 +37,15 @@ def _create_email_subject() -> str:
 
 def send_email() -> None:
     """Send e-mail with begave test reports."""
-    with open(_BEHAVE_REPORT_FILE, 'r') as fp:
+    with open(_BEHAVE_REPORT_FILE, "r") as fp:
         msg = MIMEText(fp.read(), "html")
 
-    msg['Subject'] = _create_email_subject()
-    msg['From'] = _EMAIL_FROM
-    msg['To'] = _EMAIL_TO
+    msg["Subject"] = _create_email_subject()
+    msg["From"] = _EMAIL_FROM
+    msg["To"] = _EMAIL_TO
 
     s = smtplib.SMTP(_EMAIL_SMTP_SERVER)
-    s.sendmail(msg['From'], [msg['To']], msg.as_string())
+    s.sendmail(msg["From"], [msg["To"]], msg.as_string())
     s.quit()
 
 

--- a/sendmail.py
+++ b/sendmail.py
@@ -25,7 +25,7 @@ import smtplib
 _BEHAVE_REPORT_FILE = "behave-report.html"
 _DEPLOYMENT_NAME = os.getenv("THOTH_DEPLOYMENT_NAME", "N/A")
 _EMAIL_SMTP_SERVER = os.getenv("THOTH_EMAIL_SMTP_SERVER", "smtp.corp.redhat.com")
-_EMAIL_TO = os.getenv("THOTH_EMAIL_TO", "fpokorny@redhat.com")
+_EMAIL_TO = os.getenv("THOTH_EMAIL_TO", "aicoe-thoth@redhat.com")
 _EMAIL_FROM = os.getenv("THOTH_EMAIL_FROM", "noreply@redhat.com")
 
 

--- a/sendmail.py
+++ b/sendmail.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Thoth's integration tests
-# Copyright(C) 2019 Red Hat, Inc.
+# Copyright(C) 2021 Red Hat, Inc.
 #
 # This program is free software: you can redistribute it and / or modify
 # it under the terms of the GNU General Public License as published by

--- a/test.sh
+++ b/test.sh
@@ -3,6 +3,8 @@
 export THOTH_USER_API_HOST=${THOTH_USER_API_HOST:-test.thoth-station.ninja}
 export THOTH_MANAGEMENT_API_HOST=${THOTH_MANAGEMENT_API_HOST:-management.test.thoth-station.ninja}
 export THOTH_AMUN_API_HOST=${THOTH_AMUN_API_HOST:-amun-api-thoth-test-core.apps.ocp.prod.psi.redhat.com}
+MAIL_REPORT=${MAIL_REPORT:-0}
+NO_INSTALL=${NO_INSTALL:-0}
 
 echo -e "------------------------------------------------------------------\n\n"
 echo "> Tests are executed against User API at $THOTH_USER_API_HOST"
@@ -13,5 +15,12 @@ echo -e "\n\n------------------------------------------------------------------\
 export PIPENV_HIDE_EMOJIS=1
 export PIPENV_COLORBLIND=1
 
-[[ $NO_INSTALL -eq "1" ]] || pipenv install --deploy
-pipenv --verbose run behave --tags=~@local-test-only --show-timings $@
+[[ "${NO_INSTALL}" -eq "1" ]] || pipenv install --deploy
+
+if [ "${MAIL_REPORT}" -eq "1" ]; then
+    pipenv --verbose run behave --show-timings -f html -o behave-report.html $@
+    echo "Sending generated report..."
+    pipenv run python3 sendmail.py
+else
+    pipenv --verbose run behave --show-timings $@
+fi


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## This Pull Request implements

With this change, we can send reports of integration tests via e-mail. As all the integration tests use API endpoints, we can run these on the internal network even against publicly accessible deployments and have reports sent to our mailing list.