### PR TITLE
Discard any previous config loaded to the current process

### DIFF
--- a/features/steps/advise.py
+++ b/features/steps/advise.py
@@ -229,6 +229,7 @@ def step_impl(context, runtime_environment: str, user_stack: str, static_analysi
     no_user_stack = user_stack == "without"
     no_static_analysis = static_analysis == "without"
 
+    config._configuration = None  # TODO: substitute with config.reset_config() once new thamos is released
     config.explicit_host = context.user_api_host
     with cwd(context.repo.working_tree_dir):
         try:


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## This Pull Request implements

When running integration-tests for local cloned reop and for local Pipenv files, integration tests fail as the config loaded from the last scenario (e.g. triggered from local Pipenv files) collide with the next one (e.g. advise on a cloned repo).