### PR TITLE
change the dir to runtime environment

### DIFF
--- a/features/steps/advise.py
+++ b/features/steps/advise.py
@@ -230,27 +230,29 @@ def step_impl(context, runtime_environment: str, user_stack: str, static_analysi
     no_static_analysis = static_analysis == "without"
 
     config._configuration = None  # TODO: substitute with config.reset_config() once new thamos is released
+    config.load_config_from_file(os.path.join(context.repo.working_tree_dir, ".thoth.yaml"))
     config.explicit_host = context.user_api_host
     with cwd(context.repo.working_tree_dir):
-        try:
-            results = advise_here(
-                runtime_environment_name=runtime_environment,
-                no_static_analysis=no_static_analysis,
-                no_user_stack=no_user_stack,
-                force=False,
-            )
-        finally:
-            config.reset_config()
+        with cwd(config.get_overlays_directory(runtime_environment)):
+            try:
+                results = advise_here(
+                    runtime_environment_name=runtime_environment,
+                    no_static_analysis=no_static_analysis,
+                    no_user_stack=no_user_stack,
+                    force=False,
+                )
+            finally:
+                config.reset_config()
 
-        assert isinstance(results, tuple)
+            assert isinstance(results, tuple)
 
-        if results[1] is True:
-            with open(".thoth_last_analysis_id", "r") as f:
-                analysis_id = f.readline().strip()
+            if results[1] is True:
+                with open(".thoth_last_analysis_id", "r") as f:
+                    analysis_id = f.readline().strip()
 
-            assert False, f"An error was encountered during the advise:\n{get_log(analysis_id)}"
+                assert False, f"An error was encountered during the advise:\n{get_log(analysis_id)}"
 
-        context.adviser_result = {"result": results[0]}
+            context.adviser_result = {"result": results[0]}
 
 
 @then("I should be able to see results of advise in the cloned application")


### PR DESCRIPTION
change the dir to runtime environment
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

```
py:199 2.475s
    Then I ask for an advise for the cloned application for runtime environment download-dataset, with user stack supplied and without static analysis # features/steps/advise.py:206 0.010s
      Traceback (most recent call last):
        File "/home/hnalla/.local/share/virtualenvs/integration-tests-OOjB5YLZ/lib/python3.8/site-packages/thoth/python/project.py", line 79, in from_files
          pipfile = Pipfile.from_file(pipfile_path)
        File "/home/hnalla/.local/share/virtualenvs/integration-tests-OOjB5YLZ/lib/python3.8/site-packages/thoth/python/pipfile.py", line 392, in from_file
          with open(file_path, "r") as pipfile_file:
      FileNotFoundError: [Errno 2] No such file or directory: 'Pipfile'
```

## Description

As the [advise_here](https://github.com/thoth-station/thamos/blob/36df7564f5f9cf3e6af07a95a44fab6f90d07a37/thamos/lib.py#L534) doesn't consider runtime environmnet when looking for pipfile , thus it is executed from the runtime environment. 
Ex: https://github.com/thoth-station/thamos/blob/36df7564f5f9cf3e6af07a95a44fab6f90d07a37/thamos/cli.py#L567
