### PR TITLE
updated anaylsis response check scenario and fix platform scenario name

### DIFF
--- a/features/python_platform.feature
+++ b/features/python_platform.feature
@@ -9,7 +9,7 @@ Feature: Querying Thoth to obtain Python platform information
             | platform     |
             | linux-x86_64 |
 
-    Scenario: Query for metadata for different indices for TensorFlow
+    Scenario: Query for count of available platforms
         Given deployment is accessible using HTTPS
         When I query Thoth User API for available platforms
         Then I should count 1 in the platform listing

--- a/features/steps/advise.py
+++ b/features/steps/advise.py
@@ -253,9 +253,18 @@ def step_impl(context, runtime_environment: str, user_stack: str, static_analysi
                 assert False, f"An error was encountered during the advise:\n{get_log(analysis_id)}"
 
             context.adviser_result = {"result": results[0]}
+            if ".thoth_last_analysis_id" in os.listdir():
+                with open(".thoth_last_analysis_id") as analysis_id:
+                    context.analysis_id = analysis_id.readline()
 
 
 @then("I should be able to see results of advise in the cloned application")
 def step_impl(context):
     """Ask for results of advise."""
-    raise NotImplementedError("STEP: Then I should be able to see results of advise in the cloned application")
+    assert hasattr(context, "analysis_id"), "analysis_id is not provided, which is required."
+    response = requests.get(f"{context.scheme}://{context.user_api_host}/api/v1/advise/python/{context.analysis_id}")
+    assert response.status_code == 200, (
+        f"Bad status code ({response.status_code}) when obtaining adviser result from "
+        f"{context.user_api_host}: {response.text}"
+    )
+    context.adviser_result = response.json()


### PR DESCRIPTION
updated anaylsis response check scenario and fix platform scenario name
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description

1. Defined the STEP: Then I should be able to see results of advise in the cloned application
**however if we remove this** https://github.com/thoth-station/integration-tests/blob/1dccccac2fbb2563ad5b498f0717155c6f0e8395/features/thamos_advise.feature#L22, **then step would finish correctly.**
As the `context.adviser_result` already available from advise_here.
just updated the step thinking , if we would update some more in the step in future. 
 
2. Corrected the name of the scenario.