### PR TITLE
Remove indexes removed from deployments

### DIFF
--- a/features/python_package_index.feature
+++ b/features/python_package_index.feature
@@ -8,9 +8,6 @@ Feature: Python package index
             | index_url                                                                   |
             | https://pypi.org/simple                                                     |
             | https://tensorflow.pypi.thoth-station.ninja/index/manylinux2010/AVX2/simple |
-            | https://tensorflow.pypi.thoth-station.ninja/index/rhel7.5/AVX2/simple       |
-            | https://tensorflow.pypi.thoth-station.ninja/index/rhel7.6/AVX2/simple       |
-            | https://tensorflow.pypi.thoth-station.ninja/index/rhel7.7/AVX2/simple       |
 
     Scenario: Querying for number of Python package indexes registered
         Given deployment is accessible using HTTPS

--- a/features/python_package_index.feature
+++ b/features/python_package_index.feature
@@ -12,7 +12,7 @@ Feature: Python package index
     Scenario: Querying for number of Python package indexes registered
         Given deployment is accessible using HTTPS
         When I query for the list of known Python Package indexes on User API
-        Then I should see 5 Python package indexes registered
+        Then I should see at least 2 Python package indexes registered
 
     Scenario: Querying for PyPI index on User API
         Given deployment is accessible using HTTPS

--- a/features/steps/python_package_index.py
+++ b/features/steps/python_package_index.py
@@ -71,12 +71,12 @@ def step_impl(context, index_url: str):
         assert False, f"Python package index {index_url!r} is not available on User API"
 
 
-@then("I should see {count} Python package indexes registered")
+@then("I should see at least {count} Python package indexes registered")
 def step_impl(context, count: int):
     """Verify PyPI has correct Warehouse API URL registered."""
-    assert len(context.result["indexes"]) == int(
+    assert len(context.result["indexes"]) >= int(
         count
-    ), f"Expected {count} Python package indexes registered, got {len(context.result['indexes'])}"
+    ), f"Expected at least {count} Python package indexes registered, got {len(context.result['indexes'])}"
 
 
 @then("I should see PyPI.org in the listing")


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## This Pull Request implements

RHEL 7.X indexes were unregistered from deployments.
