### PR TITLE
fix the container image testing

### DIFF
--- a/features/steps/container_images.py
+++ b/features/steps/container_images.py
@@ -41,12 +41,12 @@ def step_impl(context):
 def step_impl(context, container_image: str):
     """Verify the given container image is available on User API."""
     for entry in context.result["container_images"]:
-        if container_image == entry["thoth_s2i_image_name"]:
-            assert entry.get("thoth_s2i_image_version"), f"No version identifier found for {container_image!r}"
+        if container_image == entry["thoth_image_name"]:
+            assert entry.get("thoth_image_version"), f"No version identifier found for {container_image!r}"
             assert entry.get(
-                "analysis_id"
+                "package_extract_document_id"
             ), f"No container image analysis found for {container_image!r} Thoth container images"
-            thoth_s2i = f"{container_image}:v{entry['thoth_s2i_image_version']}"
+            thoth_s2i = f"{container_image}:v{entry['thoth_image_version']}"
             assert entry["thoth_s2i"] == thoth_s2i, (
                 f"Wrong full qualifier for {container_image!r}, expected {thoth_s2i} "
                 f"but got {entry['thoth_s2i']} instead"


### PR DESCRIPTION
fix the container image testing
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/integration-tests/issues/225

## This introduces a breaking change

- [x] Yes
- [ ] No

`thoth_s2i_image_name` and `thoth_s2i_image_version` variable are no longer in the result of container image.
https://stage.thoth-station.ninja/api/v1/container-images?page=0&per_page=25&os_name=ubi&os_version=8&python_version=3.8
