### PR TITLE
Fix type of assert_that argument

### DIFF
--- a/features/steps/python_package_metadata.py
+++ b/features/steps/python_package_metadata.py
@@ -54,12 +54,12 @@ def step_impl(context, author: str, maintainer: str):
     """Verify conditions for author and maintainer."""
     metadata = (context.result.get("importlib_metadata") or {}).get("metadata") or {}
     assert_that(metadata.get("Author"), equal_to(author))
-    assert_that(metadata.get("Maintainer"), equal_to(maintainer))
+    assert_that(str(metadata.get("Maintainer")), equal_to(maintainer))
 
 
 @when(
     'I query Thoth User API for dependencies of "{package_name}"'
-    'in version "{version}" from "{index}" for "{os_name}" "{os_version}" "{python_version}"'
+    ' in version "{version}" from "{index}" for "{os_name}" "{os_version}" "{python_version}"'
 )
 def step_impl(context, package_name: str, version: str, index: str, os_name: str, os_version: str, python_version: str):
     """Query Thoth for Python package dependencies."""


### PR DESCRIPTION
## Related Issues and Dependencies

Related to #225 

## This introduces a breaking change

- No

## This Pull Request implements

Fix type of `assert_that` first argument for the `package_metadata` feature to cover the testcase where `None` is returned in `metadata` values and avoid the following error:

```
Then I should get "Google Inc." and "None"                                                                         # features/steps/python_package_metadata.py:52 0.000s
      Assertion Failed: 
      Expected: 'None'
           but: was <None>
```