### PR TITLE
Advise can take up to 20 minutes, add some time

### DIFF
--- a/features/steps/advise.py
+++ b/features/steps/advise.py
@@ -101,7 +101,7 @@ def wait_for_adviser_to_finish(context):
     """Wait for submitted analysis to finish."""
     retries = 0
     while True:
-        if retries > timedelta(minutes=15).total_seconds():
+        if retries > timedelta(minutes=45).total_seconds():
             raise RuntimeError("Adviser analysis took too much time to finish")
 
         url = f"{context.scheme}://{context.user_api_host}/api/v1/advise/python/{context.analysis_id}"


### PR DESCRIPTION
## Related Issues and Dependencies

```
Traceback (most recent call last):
  File "/opt/app-root/lib64/python3.8/site-packages/behave/model.py", line 1329, in run
    match.run(runner.context)
  File "/opt/app-root/lib64/python3.8/site-packages/behave/matchers.py", line 98, in run
    self.func(context, *args, **kwargs)
  File "features/steps/advise.py", line 105, in wait_for_adviser_to_finish
    raise RuntimeError("Adviser analysis took too much time to finish")
RuntimeError: Adviser analysis took too much time to finish

Captured logging:
INFO:thamos.lib:Using 'STABLE' recommendation type - see https://thoth-station.ninja/recommendation-types/
INFO:thamos.lib:Successfully submitted advise analysis 'adviser-220223005709-2b54f7b779f5cd0b' to 'https://stage.thoth-station.ninja/api/v1'
```

## Description

A adviser run can take up to 20 minutes for some recommendation types. Let's add some time, also for queueing.
