### PR TITLE
Use dash instead of colon in the runtime environment entry

### DIFF
--- a/features/thamos_advise.feature
+++ b/features/thamos_advise.feature
@@ -31,7 +31,7 @@ Feature: Running thamos advise against deployment
             | https://github.com/thoth-station/elyra-aidevsecops-tutorial          | download-dataset        | without     | without         |
             | https://github.com/thoth-station/elyra-aidevsecops-tutorial          | training                | without     | without         |
             | https://github.com/thoth-station/elyra-aidevsecops-tutorial          | inference               | without     | without         |
-            | https://github.com/aicoe-aiops/ocp-ci-analysis                       | rhel:8                  | without     | without         |
+            | https://github.com/aicoe-aiops/ocp-ci-analysis                       | rhel-8                  | without     | without         |
             | https://github.com/thoth-station/ps-cv                               | ps-cv-ocr               | without     | without         |
             | https://github.com/thoth-station/ps-cv                               | ps-cv-pytorch           | without     | without         |
             | https://github.com/thoth-station/ps-cv                               | ps-cv-tensorflow        | without     | without         |


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/aicoe-aiops/ocp-ci-analysis/pull/475

## This introduces a breaking change

- [x] No
