### PR TITLE
Provide provenance-check that results in errors

### DIFF
--- a/features/data/project/provenance_flask/Pipfile
+++ b/features/data/project/provenance_flask/Pipfile
@@ -3,8 +3,20 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 name = "pypi"
 
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi-org-simple"
+
 [packages]
 flask = "*"
 
+[dev-packages]
+
 [requires]
 python_version = "3.8"
+
+[thoth]
+disable_index_adjustment = false
+
+[thoth.allow_prereleases]

--- a/features/data/project/provenance_flask_error/Pipfile
+++ b/features/data/project/provenance_flask_error/Pipfile
@@ -1,0 +1,10 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+flask = "*"
+
+[requires]
+python_version = "3.8"

--- a/features/data/project/provenance_flask_error/Pipfile.lock
+++ b/features/data/project/provenance_flask_error/Pipfile.lock
@@ -33,7 +33,7 @@
         },
         "flask": {
             "hashes": [
-                "sha256:cb90f62f1d8e4dc4621f52106613488b5ba826b2e1e10a33eac92f723093ab6a",
+                "sha256:deadbeef",
                 "sha256:7b2fb8e934ddd50731893bdcdb00fc8c0315916f9fcd50d22c7cc1a95ab634e2",
                 "sha256:cb90f62f1d8e4dc4621f52106613488b5ba826b2e1e10a33eac92f723093ab6a",
                 "sha256:7b2fb8e934ddd50731893bdcdb00fc8c0315916f9fcd50d22c7cc1a95ab634e2"

--- a/features/steps/provenance_check.py
+++ b/features/steps/provenance_check.py
@@ -94,9 +94,17 @@ def step_impl(context):
     context.provenance_result = response.json()
 
 
-@then("I should be able to see successful results of provenance check")
-def step_impl(context):
+@then("I should be able to see {result} provenance check results")
+def step_impl(context, result: str):
     """Check provenance-checker result."""
+    assert result in ("successful", "failed"), "Unknown result expectation"
+    any_error = result != "successful"
+
     assert (
         context.provenance_result["result"]["error"] is False
     ), f"Provenance check {context.analysis_id!r} was not successful"
+
+    if any_error:
+        assert any(i["type"] == "ERROR" for i in context.provenance_result["result"]["report"])
+    else:
+        assert all(i["type"] != "ERROR" for i in context.provenance_result["result"]["report"])

--- a/features/thamos_provenance_check.feature
+++ b/features/thamos_provenance_check.feature
@@ -6,8 +6,9 @@ Feature: Provenance checks of Python software stacks
         When thamos provenance-check is run for <provenance_check_case> asynchronously
         Then wait for provenance-checker to finish successfully
         Then I should be able to retrieve provenance-checker results
-        Then I should be able to see successful results of provenance check
+        Then I should be able to see <result> provenance check results
 
         Examples: Provenance
-            | provenance_check_case     |
-            | provenance_flask          |
+            | provenance_check_case     |     result          |
+            | provenance_flask          |     successful      |
+            | provenance_flask_error    |     failed          |


### PR DESCRIPTION
## Related Issues and Dependencies

Related: #268 
Closes: #267 

## This introduces a breaking change

- [x] No

## Description

Implement provenance-check that produces errors. Also, update lockfile of the old provenance-check to respect data we have in prod deployment.

