### PR TITLE
Remove ocp-ci-analysis repo

### DIFF
--- a/features/thamos_advise.feature
+++ b/features/thamos_advise.feature
@@ -31,7 +31,6 @@ Feature: Running thamos advise against deployment
             | https://github.com/thoth-station/elyra-aidevsecops-tutorial          | download-dataset        | without     | without         |
             | https://github.com/thoth-station/elyra-aidevsecops-tutorial          | training                | without     | without         |
             | https://github.com/thoth-station/elyra-aidevsecops-tutorial          | inference               | without     | without         |
-            | https://github.com/aicoe-aiops/ocp-ci-analysis                       | rhel-8                  | without     | without         |
             | https://github.com/thoth-station/ps-cv                               | ps-cv-ocr               | without     | without         |
             | https://github.com/thoth-station/ps-cv                               | ps-cv-pytorch           | without     | without         |
             | https://github.com/thoth-station/ps-cv                               | ps-cv-tensorflow        | without     | without         |


### PR DESCRIPTION
## Related Issues and Dependencies

Related: #255 

## This introduces a breaking change

- [x] No

## Description

If our changes will not be accepted, we will have to remove ocp-ci-analysis repo from our integration tests.
