### PR TITLE
Remove default for platform boot

### DIFF
--- a/features/data/dependency_monkey/flask/pipeline.yaml
+++ b/features/data/dependency_monkey/flask/pipeline.yaml
@@ -5,8 +5,7 @@ boots:
   name: PythonVersionBoot
 - configuration: {}
   name: RHELVersionBoot
-- configuration:
-    default_platform: linux-x86_64
+- configuration: {}
   name: PlatformBoot
 - configuration: {}
   name: FullySpecifiedEnvironment

--- a/features/data/dependency_monkey/simple_tensorflow/pipeline.yaml
+++ b/features/data/dependency_monkey/simple_tensorflow/pipeline.yaml
@@ -5,8 +5,7 @@ boots:
   name: PythonVersionBoot
 - configuration: {}
   name: RHELVersionBoot
-- configuration:
-    default_platform: linux-x86_64
+- configuration: {}
   name: PlatformBoot
 - configuration: {}
   name: FullySpecifiedEnvironment


### PR DESCRIPTION
## Related Issues and Dependencies

Platform boot no longer accepts `default_platform` as a configuration.