### PR TITLE
Tag solver scenario to be omitted in stage

### DIFF
--- a/features/solvers.feature
+++ b/features/solvers.feature
@@ -4,6 +4,7 @@ Feature: Check for minimum solvers available in Thoth
         When we ask for the available solvers
         Then they should include at least the minimum set of solvers
 
+    @seizes_middletier_namespace
     Scenario: Schedule solver jobs for all available solvers in Thoth
         Given deployment is accessible using HTTPS
         When we ask for the available solvers


### PR DESCRIPTION
## Related Issues and Dependencies

Related to https://github.com/thoth-station/integration-tests/issues/250#issuecomment-1063099538

## This introduces a breaking change

- No

## This Pull Request implements

Tag the `Schedule solver jobs for all available solvers in Thoth` scenario of the `solver` feature to be excluded when running integration tests in stage (see comment linked above).
