### PR TITLE
Remove count and limit parameters from advise query

### DIFF
--- a/features/steps/advise.py
+++ b/features/steps/advise.py
@@ -90,8 +90,6 @@ def thamos_advise(context, case: str, recommendation_type: str, os_name: str, os
         },
         nowait=True,
         force=True,
-        limit=None,
-        count=1,
         debug=False,
     )
 


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes https://github.com/thoth-station/integration-tests/issues/305

## This introduces a breaking change

- No

## This Pull Request implements

Remove the `count` and `limit` parameters from the advise query as they were [removed from the API advise endpoint](https://github.com/thoth-station/user-api/pull/1727).
