### PR TITLE
Attach `thoth` and `thamos` versions to tests report email

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,6 +22,8 @@ from datetime import date
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 from email.mime.application import MIMEApplication
+from thamos.config import config
+from thamos.lib import thamos_version
 import os
 import smtplib
 import sys
@@ -69,6 +71,8 @@ def send_email() -> None:
     msg["From"] = _EMAIL_FROM
     msg["To"] = _EMAIL_TO
     msg.attach(MIMEText(report, "html"))  # Message body.
+    msg.attach(MIMEText(f"Thoth version: {config.get_thoth_version()}\n"))
+    msg.attach(MIMEText(f"Thamos version: {thamos_version}"))
 
     attachment = MIMEApplication(report, _subtype="html")
     attachment.add_header("content-disposition", "attachment", filename=_BEHAVE_REPORT_FILE)


### PR DESCRIPTION
## Related Issues and Dependencies

Related to https://github.com/thoth-station/integration-tests/issues/313#issuecomment-1095470455

## This introduces a breaking change

- No

## This Pull Request implements

Attach the versions of `thoth` and `thamos` used in the integration tests to the report email.
Other methods consisting in having those versions in the report itself failed because `behave` systematically overwrites the output generated when running the tests. It is possible to get this output when running tests on the command line but it does not seem to be the case for the report itself.
