### PR TITLE
Increase provenance-check test time limit

### DIFF
--- a/features/steps/provenance_check.py
+++ b/features/steps/provenance_check.py
@@ -53,7 +53,7 @@ def step_impl(context):
     """Wait for submitted provenance-checker to finish."""
     retries = 0
     while True:
-        if retries > timedelta(minutes=15).total_seconds():
+        if retries > timedelta(minutes=30).total_seconds():
             raise RuntimeError("provenance-checker took too much time to finish")
 
         url = f"{context.scheme}://{context.user_api_host}/api/v1/provenance/python/{context.analysis_id}"


### PR DESCRIPTION
## Related Issues and Dependencies
Related to https://github.com/thoth-station/integration-tests/issues/309

## This introduces a breaking change

- No

## This Pull Request implements
Provenance-check integration tests are still failing on `ocp4-stage` whereas the resources issue affecting the psi cluster on which the provenance-checks are running has been solved. This increase should allow to verify if the issue comes from provenance-checks themselves or from the cluster.
